### PR TITLE
fix: updated old Draw namespace, removed Coroutine wrapping

### DIFF
--- a/Main.as
+++ b/Main.as
@@ -62,7 +62,8 @@ void Update(float dt){
 
 void StartConnection(){
     socket.OpenSocket();
-    startnew(CoroutineFunc(ConnectedLoop));
+    // startnew(CoroutineFunc(ConnectedLoop));
+    startnew(ConnectedLoop);
 }
 
 int lastRaceTime = -1;

--- a/UI/Celebration/Confetti.as
+++ b/UI/Celebration/Confetti.as
@@ -54,11 +54,11 @@ class ConfettiStrip{
 
     float RefToScreen(float x){
         //scale by screen height
-        return x * float(Draw::GetHeight())/1080.0;
+        return x * float(Display::GetHeight())/1080.0;
     }
 
     vec2 RefToScreen(vec2 x){
         //scale by screen height
-        return x * float(Draw::GetHeight())/1080.0;
+        return x * float(Display::GetHeight())/1080.0;
     }
 }

--- a/UI/Celebration/PopupText.as
+++ b/UI/Celebration/PopupText.as
@@ -36,7 +36,7 @@ class PopupText{
         float size = 0;
         float opacity = 0;
         vec2 gradientPos = vec2(0.0,0.0);
-        //float shineWidthAdj = shineWidth * Draw::GetHeight()/1080.0;
+        //float shineWidthAdj = shineWidth * Display::GetHeight()/1080.0;
         if (timer < inDuration){
             float t = timer/inDuration;
             size = Math::Lerp(startSize,displaySize,t);
@@ -46,8 +46,8 @@ class PopupText{
             size = displaySize;
             nvg::FontSize(size);
             // vec2 b = nvg::TextBounds(text);
-            // float start = -b.x/2-shineWidthAdj+Draw::GetWidth()*pos.x;
-            // float end = b.x/2+shineWidthAdj+Draw::GetWidth()*pos.x;
+            // float start = -b.x/2-shineWidthAdj+Display::GetWidth()*pos.x;
+            // float end = b.x/2+shineWidthAdj+Display::GetWidth()*pos.x;
             // gradientPos.x = Math::Lerp(start,end,t);
             // gradientPos.y = 500;
             opacity = 1;
@@ -59,18 +59,18 @@ class PopupText{
         }else{
             return;
         }
-        size = size*Draw::GetHeight()/1080.0;
+        size = size*Display::GetHeight()/1080.0;
         nvg::FontSize(size);
         vec2 bounds = nvg::TextBounds(text);
-        vec2 textPos = vec2(Draw::GetWidth()*pos.x,Draw::GetHeight()*pos.y)+vec2(-bounds.x/2,bounds.y/4);
-        vec2 shadowPos = textPos + vec2(shadowOffset.x*Draw::GetHeight()/1080,shadowOffset.y*Draw::GetHeight()/1080);
+        vec2 textPos = vec2(Display::GetWidth()*pos.x,Display::GetHeight()*pos.y)+vec2(-bounds.x/2,bounds.y/4);
+        vec2 shadowPos = textPos + vec2(shadowOffset.x*Display::GetHeight()/1080,shadowOffset.y*Display::GetHeight()/1080);
         
         nvg::BeginPath();
         nvg::SkewX(-10*Math::PI/180);
         nvg::FillColor(vec4(shadowColor.x,shadowColor.y,shadowColor.z,shadowColor.w*opacity*0.75));
-        vec2 boxBounds = bounds + vec2(120,10)*Draw::GetHeight()/1080.0;
-        vec2 boxPos = vec2(Draw::GetWidth()*pos.x,Draw::GetHeight()*pos.y)+vec2(-boxBounds.x/2,-boxBounds.y/2);
-        boxPos.x += 130*Draw::GetHeight()/1080.0;
+        vec2 boxBounds = bounds + vec2(120,10)*Display::GetHeight()/1080.0;
+        vec2 boxPos = vec2(Display::GetWidth()*pos.x,Display::GetHeight()*pos.y)+vec2(-boxBounds.x/2,-boxBounds.y/2);
+        boxPos.x += 130*Display::GetHeight()/1080.0;
         nvg::RoundedRectVarying(boxPos,boxBounds,20,0,20,0);
         nvg::Fill();
         nvg::ClosePath();

--- a/UI/Common.as
+++ b/UI/Common.as
@@ -89,7 +89,7 @@ void RenderMedalProgress(UI::Texture@ tex, float size, int count, int total){
 }
 
 void RenderTextCentered(const string &in text, UI::Font@ font, int fontSize){
-    vec2 size = Draw::MeasureString(text, font, fontSize);
+    vec2 size = UI::MeasureString(text, font, fontSize);
     MoveCursor(size/-2);
     UI::PushFont(font);
     UI::PushFontSize(fontSize);

--- a/UI/MainMenu.as
+++ b/UI/MainMenu.as
@@ -146,7 +146,7 @@ void RenderMainMenu(){
                 int count = data.items.GetProgressionMedalCount();
                 int total = (nextSeries < data.world.Length) ? data.world[nextSeries].medalRequirement : data.victoryRequirement;
                 int size = 60;
-                float medalOffset = (viewSize.x/2)-((size+Draw::MeasureString(""+count+"/"+total,fontHeaderSub).x)/2+16*UI::GetScale());
+                float medalOffset = (viewSize.x/2)-((size+UI::MeasureString(""+count+"/"+total,fontHeaderSub).x)/2+16*UI::GetScale());
                 RenderSeriesLine(nextSeries,viewSize,40,4,8);
                 MoveCursor(vec2(medalOffset,-15.0));
                 RenderMedalProgress(GetProgressionTex(),size,count,total);
@@ -164,7 +164,7 @@ void RenderMainMenu(){
                         color = (vec4(0.0,1.0,0.1,1.0));
                     }
                     UI::PushStyleColor(UI::Col::Text,color);
-                    vec2 stringSize = Draw::MeasureString(text,fontHeader);
+                    vec2 stringSize = UI::MeasureString(text,fontHeader);
                     float textOffset = (viewSize.x/2)-(stringSize.x/2);
                     MoveCursor(vec2(textOffset,0.0));
                     UI::Text(text);
@@ -313,7 +313,7 @@ void RenderMainMenuThumbnail(){
                 int count = data.items.GetProgressionMedalCount();
                 int total = (nextSeries < data.world.Length) ? data.world[nextSeries].medalRequirement : data.victoryRequirement;
                 int size = 60;
-                float medalOffset = (viewSize.x/2)-((size+Draw::MeasureString(""+count+"/"+total,fontHeaderSub).x)/2+16*UI::GetScale());
+                float medalOffset = (viewSize.x/2)-((size+UI::MeasureString(""+count+"/"+total,fontHeaderSub).x)/2+16*UI::GetScale());
                 RenderSeriesLine(nextSeries,viewSize,40,4,8);
                 MoveCursor(vec2(medalOffset,-15.0));
                 RenderMedalProgress(GetProgressionTex(),size,count,total);
@@ -330,7 +330,7 @@ void RenderMainMenuThumbnail(){
                         color = (vec4(0.0,1.0,0.1,1.0));
                     }
                     UI::PushStyleColor(UI::Col::Text,color);
-                    vec2 stringSize = Draw::MeasureString(text,fontHeader);
+                    vec2 stringSize = UI::MeasureString(text,fontHeader);
                     float textOffset = (viewSize.x/2)-(stringSize.x/2);
                     MoveCursor(vec2(textOffset,0.0));
                     UI::Text(text);

--- a/UI/PlaygroundMedals.as
+++ b/UI/PlaygroundMedals.as
@@ -304,8 +304,8 @@ void ReplaceMedalText(CGameManialinkLabel@ QuadLabel, const string &in imageURL)
 }
 
 void DrawBigMedal(vec2 medalPos, float medalScale, const string &in imageURL){
-    const float w      = Math::Max(1, Draw::GetWidth());
-    const float h      = Math::Max(1, Draw::GetHeight());
+    const float w      = Math::Max(1, Display::GetWidth());
+    const float h      = Math::Max(1, Display::GetHeight());
     const vec2  center = vec2(w * 0.5f, h * 0.5f);
     const float hUnit  = h / 180.0f;
     const vec2  scale  = vec2((w / h > stdRatio) ? hUnit : w / 320.0f, -hUnit);
@@ -343,8 +343,8 @@ void DrawBigMedal(vec2 medalPos, float medalScale, const string &in imageURL){
 }
 
 void DrawHugeMedal(vec2 medalPos, float medalScale, const string &in imageURL){
-    const float w      = Math::Max(1, Draw::GetWidth());
-    const float h      = Math::Max(1, Draw::GetHeight());
+    const float w      = Math::Max(1, Display::GetWidth());
+    const float h      = Math::Max(1, Display::GetHeight());
     const vec2  center = vec2(w * 0.5f, h * 0.5f);
     const float hUnit  = h / 180.0f;
     const vec2  scale  = vec2((w / h > stdRatio) ? hUnit : w / 320.0f, -hUnit);
@@ -377,8 +377,8 @@ void DrawHugeMedal(vec2 medalPos, float medalScale, const string &in imageURL){
 }
 
 void DrawMedals(vec2 medalPos, PlaygroundPageType type){
-    const float w      = Math::Max(1, Draw::GetWidth());
-    const float h      = Math::Max(1, Draw::GetHeight());
+    const float w      = Math::Max(1, Display::GetWidth());
+    const float h      = Math::Max(1, Display::GetHeight());
     const vec2  center = vec2(w * 0.5f, h * 0.5f);
     const float hUnit  = h / 180.0f;
     const vec2  scale  = vec2((w / h > stdRatio) ? hUnit : w / 320.0f, -hUnit);

--- a/UI/PlaygroundMedalsMP4.as
+++ b/UI/PlaygroundMedalsMP4.as
@@ -67,8 +67,8 @@ void DrawPlaygroundUI() {
 }
 
 void DrawMedalSelection(CControlQuad@ Medal){
-    const float w      = Math::Max(1, Draw::GetWidth());
-    const float h      = Math::Max(1, Draw::GetHeight());
+    const float w      = Math::Max(1, Display::GetWidth());
+    const float h      = Math::Max(1, Display::GetHeight());
     const vec2  center = vec2(w * 0.5f, h * 0.5f);
     const vec2  scale  = vec2(w*-0.3125,h*-0.55555556);
 
@@ -94,8 +94,8 @@ void DrawMedalSelection(CControlQuad@ Medal){
 }
 
 void DrawBigMedals(CControlFrame@ BigMedalsParent){
-    const float w      = Math::Max(1, Draw::GetWidth());
-    const float h      = Math::Max(1, Draw::GetHeight());
+    const float w      = Math::Max(1, Display::GetWidth());
+    const float h      = Math::Max(1, Display::GetHeight());
     const vec2  center = vec2(w * 0.5f, h * 0.5f);
     const vec2  scale  = vec2(w*-0.3125,h*-0.55555556);
 
@@ -193,8 +193,8 @@ void DrawBigMedals(CControlFrame@ BigMedalsParent){
 
 
 bool DrawBigMedal (CControlQuad@ Medal, CheckTypes type, int shift = 0){
-    const float w      = Math::Max(1, Draw::GetWidth());
-    const float h      = Math::Max(1, Draw::GetHeight());
+    const float w      = Math::Max(1, Display::GetWidth());
+    const float h      = Math::Max(1, Display::GetHeight());
     const vec2  center = vec2(w * 0.5f, h * 0.5f);
     const vec2  scale  = vec2(w*-0.3125,h*-0.55555556);
     mat4 mat = Medal.Item.Corpus.Location;
@@ -227,8 +227,8 @@ bool DrawBigMedal (CControlQuad@ Medal, CheckTypes type, int shift = 0){
 }
 
 void DrawBowTie (CControlQuad@ BowTie, int shifts){
-    const float w      = Math::Max(1, Draw::GetWidth());
-    const float h      = Math::Max(1, Draw::GetHeight());
+    const float w      = Math::Max(1, Display::GetWidth());
+    const float h      = Math::Max(1, Display::GetHeight());
     const vec2  center = vec2(w * 0.5f, h * 0.5f);
     const vec2  scale  = vec2(w*-0.3125,h*-0.55555556);
     mat4 mat = BowTie.Item.Corpus.Location;


### PR DESCRIPTION
Hey,

I updated the old Draw namespace to the current ones, which simply had been moved apparently.

Im not sure about my fix to this error:
`ArchipelagoPlugin.op/:/Main.as (65, 14) :  ERR : Can't create delegate for types that do not support handles`
All I did was remove the coroutine part since it didn't seem necessary for the plugin to function, but I might have missed something.