### PR TITLE
Add Track of the Day (TOTD) option for custom series

### DIFF
--- a/DataContainers/SearchCriteria.as
+++ b/DataContainers/SearchCriteria.as
@@ -17,6 +17,7 @@ class SearchCriteria {
     int min_length;
     int max_length; // By default, always set to 5 minutes in slot_data (see also: MAX_AUTHOR_TIME)
     bool has_award;
+    bool in_totd;
     bool has_replay;
 
     SearchCriteria(int seriesI, const Json::Value &in json, bool fromSlotData = false) {
@@ -53,6 +54,7 @@ class SearchCriteria {
             this.min_length = json.Get("min_length", 0);
             this.max_length = json.Get("max_length", 0);
             this.has_award = JsonGetAsBool(json, "has_award");
+            this.in_totd = JsonGetAsBool(json, "in_totd");
             this.has_replay = JsonGetAsBool(json, "has_replay");
         }
         catch {
@@ -80,6 +82,7 @@ class SearchCriteria {
             json["min_length"] = this.min_length;
             json["max_length"] = this.max_length;
             json["has_award"] = this.has_award;
+            json["in_totd"] = this.in_totd;
             json["has_replay"] = this.has_replay;
         }
         catch {
@@ -128,7 +131,9 @@ class SearchCriteria {
             if (this.max_length > 0)
                 params.Set("authortimemax", tostring(this.max_length));
             if (this.has_award)
-                params.Set("inlatestawardedauthor", "1");                
+                params.Set("inlatestawardedauthor", "1");  
+            if (this.in_totd)
+                params.Set("intotd", "1");              
             if (this.has_replay)
                 params.Set("inhasreplay", "1");
         }


### PR DESCRIPTION
### What this does

Adds an option for custom series to filter by Track of the Day (TOTD) tracks.

### Details

* Adds a toggle to turn TOTD maps on/off
* Keeps everything working with current filters and progression

### Example usage

```
custom_series:
      all:
        has_award: true
        in_totd: true

      1:
        map_tags: ["LOL"]
        difficulties: ["Beginner", "Intermediate"]
        uploaded_after: "2019-12-31"
      2:
        map_tags: ["Tech"]
        min_length: 40000
        max_length: 75000
```

### Notes

* Off by default
* No breaking changes
* [Discord thread with go-ahead from SerialBoxes](https://discord.com/channels/731205301247803413/1368696493904625785/1488378740332433560)

Ty! :D