### PR TITLE
Alternate points system

### DIFF
--- a/DataContainers/Items.as
+++ b/DataContainers/Items.as
@@ -65,6 +65,38 @@ class Items{
         }
     }
 
+    int GetPointCount(){
+        float targetTimeSetting = saveData.settings.targetTimeSetting;
+        if (targetTimeSetting < 1.0){
+            return bronzeMedals * 10;
+        }else if (targetTimeSetting < 2.0){
+            pointCount = silverMedals * 7 + bronzeMedals * 3
+            return pointCount;
+        }else if (targetTimeSetting < 3.0){
+            pointCount = goldMedals * 5 + silverMedals * 3 + bronzeMedals * 2
+            return pointCount;
+        }else {
+            pointCount = authorMedals*5 + goldMedals*3 + silverMedals*1 + bronzeMedals*1
+            return pointCount;;
+        }
+    }
+
+    int GetEqualizedPointCount(){
+        float targetTimeSetting = saveData.settings.targetTimeSetting;
+        if (targetTimeSetting < 1.0){
+            return bronzeMedals * 12;
+        }else if (targetTimeSetting < 2.0){
+            pointCount = (silverMedals + bronzeMedals) * 6
+            return pointCount;
+        }else if (targetTimeSetting < 3.0){
+            pointCount = (goldMedals + silverMedals + bronzeMedals) * 4 
+            return pointCount;
+        }else {
+            pointCount = (authorMedals + goldMedals + silverMedals + bronzeMedals) * 3
+            return pointCount;;
+        }
+    }
+
     void AddItem (int itemID, int itemCount = 1) {
         switch (itemID){
             case ItemTypes::BronzeMedal:

--- a/DataContainers/YamlSettings.as
+++ b/DataContainers/YamlSettings.as
@@ -6,6 +6,7 @@ class YamlSettings{
     bool silverDisabled;
     bool goldDisabled;
     bool authorDisabled;
+    int pointSystem; 
 
     YamlSettings() {
         targetTimeSetting = 0.0;
@@ -44,6 +45,7 @@ class YamlSettings{
         Json::Value json = Json::Object();
         try {
             json["targetTimeSetting"] = targetTimeSetting;
+            json["pointSystem"] = pointSystem;
             json["discountAmount"] = discountAmount;
             json["seriesCount"] = seriesCount;
             json["bronzeDisabled"] = bronzeDisabled;
@@ -59,6 +61,7 @@ class YamlSettings{
     void ReadSlotData(const Json::Value &in json){
         seriesCount = json["SeriesNumber"];
         targetTimeSetting = json["TargetTimeSetting"];
+        pointSystem = json["PointSystem"]
         discountAmount = json.Get("DiscountAmount",0.015);
         bronzeDisabled = JsonGetAsBool(json, "DisableBronze");
         silverDisabled = JsonGetAsBool(json, "DisableSilver");
@@ -68,6 +71,7 @@ class YamlSettings{
 
     void ReadJsonV1_2(const Json::Value &in json){
         targetTimeSetting = json["targetTimeSetting"];
+        pointSystem = json["pointSystem"]
         discountAmount = json["discountAmount"];
         seriesCount = json["seriesCount"];
         bronzeDisabled = JsonGetAsBool(json, "bronzeDisabled");


### PR DESCRIPTION
In this branch i develop new point systems for the mod. 
The general idea is that with the current system, among the 5 checks per maps 3 of them are 100% useless and 1 is very likely to also be fodder. My idea is to give value to medals (ex: author medals = 4points, gold medals = 3points, silver medals = 2points, bronze medals = 1point) while still retaining the target time setting which I believe to be a great difficulty setting. 
In the end I want it to be an option between the old progression system and the point system as I believe the more options there are the better. This means another part of the project is an update of the apworld I am developping on the side.